### PR TITLE
Bug with repeating processing of all previously received frames on each data event

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -7,13 +7,13 @@
     Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
     * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or 
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or
       other materials provided with the distribution.
     * Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software
       without specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
     COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
     HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -115,6 +115,10 @@ function _connect(stomp) {
     socket.on('data', function(chunk) {
         buffer += chunk;
         var frames = buffer.split('\0\n');
+
+        if (frames.length == 1) return;
+        buffer = frames.pop();
+
         var parsed_frame = null;
         var _frame = null;
         while (_frame = frames.shift()) {


### PR DESCRIPTION
Hi, Benjamin! I believe I've fixed bug with repeating processing of all previously received frames on each data event.
The fix is working for me with ActiveMQ server, both for sending and receiving messages.
It is looking like stomp input buffer was never cleaned up after/before a frame is processed.
Please consider merging my changes.
Best regards, Alexander
