### PR TITLE
Adding support for vhost host header (required in Stomp 1.1 protocol)

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -131,6 +131,9 @@ function _setupListeners(stomp) {
         if (utils.really_defined(stomp["client-id"])) {
             headers["client-id"] = stomp["client-id"];
         }
+        if (utils.really_defined(stomp["vhost"])) {
+            headers["host"] = stomp["vhost"];
+        }
         stomp_connect(stomp, headers);
     }
 
@@ -258,6 +261,9 @@ function Stomp(args) {
     this.ssl_validate = args['ssl_validate'] ? true : false;
     this.ssl_options = args['ssl_options'] || {};
     this['client-id'] = args['client-id'] || null;
+    if(typeof args.vhost !== 'undefined'){
+        this.vhost = args['vhost'] ;
+    }
 };
 
 // ## Stomp is an EventEmitter


### PR DESCRIPTION
We recently switched to using Vhosts to segment our queues and I need to use the host header defined in the Stomp 1.1 protocol. 

http://stomp.github.com/stomp-specification-1.1.html#CONNECT_or_STOMP_Frame

I'm actually not that familiar with the Stomp changes for the 1.0 => 1.1 protocol shift. I'd be happy to add them too if you really care to support it. The vhost header was all I needed to get my project back on track after our change in queue management.

i.e.  I am creating my client like this:

``` javascript
var client = new stomp.Stomp({
    port: 61613,
    host: 'rmq',
    vhost: 'MY_VIRTUAL_HOST_HEADER',
    debug: true,
});
```
