### PR TITLE
Use util.inherit for EventEmitter inheritance

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -20,9 +20,11 @@
 
 // ## Helpers to handle frames, and do parsing
 
-var net = require('net'),
+var events = require('events'),
+    net = require('net'),
     tls = require('tls'),
     sys = require('util'),
+    util = require('util'),
     frame = require('./frame'),
     stomp_utils = require('./stomp-utils'),
     exceptions = require('./stomp-exceptions'),
@@ -245,6 +247,8 @@ function send_frame(stomp, _frame) {
 // Takes an argument object
 //
 function Stomp(args) {
+    events.EventEmitter.call(this);
+
     this.port = args['port'] || 61613;
     this.host = args['host'] || '127.0.0.1';
     this.debug = args['debug'];
@@ -263,7 +267,7 @@ function Stomp(args) {
 };
 
 // ## Stomp is an EventEmitter
-Stomp.prototype = new process.EventEmitter();
+util.inherits(Stomp, events.EventEmitter);
 
 // ## Stomp.connect()
 //


### PR DESCRIPTION
I saw there was already an issue regarding this but I wanted to submit a pr to fix it.

To read more about the problem, please see:
https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10
