### PR TITLE
Add keep alive to socket

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -137,6 +137,8 @@ function _setupListeners(stomp) {
 
     var socket = stomp.socket;
 
+    socket.setKeepAlive(true);
+
     socket.on('drain', function(data) {
         log.debug('draining');
     });


### PR DESCRIPTION
This one prevents closing sockets by external service. It happens that after 2 minutes socket is closed by remote, and there is no event connected to it. I expected to get timeout event, but it is never happened in my case.