### PR TITLE
fix check for missing subscription

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -295,7 +295,7 @@ Stomp.prototype.is_a_message = function(this_frame) {
 //
 Stomp.prototype.should_run_message_callback = function(this_frame) {
     var subscription = this._subscribed_to[this_frame.headers.destination];
-    if (this_frame.headers.destination !== null && subscription !== null) {
+    if (this_frame.headers.destination !== null && subscription) {
         if (subscription.enabled && subscription.callback !== null && typeof(subscription.callback) == 'function') {
             subscription.callback(this_frame.body, this_frame.headers);
         }


### PR DESCRIPTION
When a map doesn't have a value for a key it returns `undefined` not `null`.