### PR TITLE
If the length of the header array is 1 or 0 then it makes no sense to…

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -51,7 +51,6 @@ function parse_headers(raw_headers) {
             headers[header_key] = header_val;
             continue;
         }
-        headers[header[0].trim()] = header[1].trim();
     }
     return headers;
 };


### PR DESCRIPTION
… try to access index 1, I had it crash on me, but worked well with this removal of code which seems quite ilogical to have there, legacy?